### PR TITLE
why page and how page fixed

### DIFF
--- a/frontend/src/pages/user/HowPage.jsx
+++ b/frontend/src/pages/user/HowPage.jsx
@@ -6,6 +6,14 @@ import { useTheme } from '../../context/ThemeContext'
 
 const TOTAL_QUESTION_STEPS = 5
 
+const HOW_QUESTIONS = [
+  'How do you vision a better outcome for this issue?',
+  'What are the key steps needed to achieve that?',
+  'How could that be improved or implemented?',
+  'Who needs to take action, and what should they do?',
+  'Ultimately, what is the very first small step we can take right now?',
+]
+
 const slideVariants = {
   enter:  (dir) => ({ x: dir * 48, opacity: 0 }),
   center: { x: 0, opacity: 1, transition: { duration: 0.28, ease: [0.25, 0.46, 0.45, 0.94] } },
@@ -23,6 +31,7 @@ export default function HowPage() {
   const [answers, setAnswers]         = useState(Array(TOTAL_QUESTION_STEPS).fill(''))
   const [submitting, setSubmitting]   = useState(false)
   const [hoveredNav, setHoveredNav]   = useState(null)
+  const [isCompactNav, setIsCompactNav] = useState(false)
 
   const inputRef = useRef(null)
   const topRef   = useRef(null)
@@ -37,6 +46,16 @@ export default function HowPage() {
     inputRef.current?.focus()
     topRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }, [currentStep])
+
+  useEffect(() => {
+    const updateNavLayout = () => {
+      setIsCompactNav(window.innerWidth < 420)
+    }
+
+    updateNavLayout()
+    window.addEventListener('resize', updateNavLayout)
+    return () => window.removeEventListener('resize', updateNavLayout)
+  }, [])
 
   const submitHow = async () => {
     if (submitting) return
@@ -135,9 +154,7 @@ export default function HowPage() {
         >
           {/* Question label */}
           <p style={{ fontWeight: 600, fontSize: 20, color: textColor, marginBottom: 60 }}>
-            {currentStep === 1
-              ? 'How could this be improved?'
-              : 'How could that be improved?'}
+            {HOW_QUESTIONS[questionIdx]}
           </p>
 
           {/* Info hint */}
@@ -197,7 +214,7 @@ export default function HowPage() {
           />
 
           {/* Navigation row */}
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginTop: 14, gap: 10, flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginTop: 14, gap: 10, flexWrap: 'nowrap' }}>
 
             {/* Back */}
             <button
@@ -206,15 +223,17 @@ export default function HowPage() {
               onMouseEnter={() => currentStep !== 1 && setHoveredNav('back')}
               onMouseLeave={() => setHoveredNav(null)}
               style={{
-                padding: '10px 18px',
+                padding: isCompactNav ? '9px 12px' : '10px 18px',
                 borderRadius: 10,
                 border: `1px solid ${isDark ? 'rgba(255,255,255,0.12)' : '#ddd'}`,
                 background: hoveredNav === 'back' ? (isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.04)') : 'transparent',
                 color: currentStep === 1 ? (isDark ? 'rgba(255,255,255,0.2)' : '#ccc') : textColor,
                 fontWeight: 600,
-                fontSize: 14,
+                fontSize: isCompactNav ? 13 : 14,
                 fontFamily: 'Poppins, sans-serif',
                 cursor: currentStep === 1 ? 'not-allowed' : 'pointer',
+                whiteSpace: 'nowrap',
+                flexShrink: 0,
                 transition: 'all 0.15s',
               }}
             >
@@ -222,10 +241,10 @@ export default function HowPage() {
             </button>
 
             {/* Right side: I don't know + Next/Finish */}
-            <div style={{ display: 'flex', gap: 8, alignItems: 'flex-end', flexWrap: 'wrap' }}>
+            <div style={{ display: 'flex', gap: isCompactNav ? 6 : 8, alignItems: 'flex-end', flexWrap: 'nowrap', justifyContent: 'flex-end', minWidth: 0, flex: 1 }}>
               {currentStep >= 2 && (
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'flex-end' }}>
-                  <span style={{ fontSize: 11, color: subText, maxWidth: 200, textAlign: 'right', lineHeight: 1.4 }}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'flex-end', minWidth: 0, flexShrink: 1 }}>
+                  <span style={{ display: isCompactNav ? 'none' : 'block', fontSize: 11, color: subText, maxWidth: 200, textAlign: 'right', lineHeight: 1.4 }}>
                     Unsure how to continue? This would end follow-ups.
                   </span>
                   <button
@@ -234,20 +253,22 @@ export default function HowPage() {
                     onMouseEnter={() => !submitting && setHoveredNav('idontknow')}
                     onMouseLeave={() => setHoveredNav(null)}
                     style={{
-                      padding: '10px 18px',
+                      padding: isCompactNav ? '9px 12px' : '10px 18px',
                       borderRadius: 10,
                       border: `1px solid ${isDark ? 'rgba(255,255,255,0.18)' : '#bbb'}`,
                       background: hoveredNav === 'idontknow' ? (isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.05)') : 'transparent',
                       color: textColor,
                       fontWeight: 600,
-                      fontSize: 14,
+                      fontSize: isCompactNav ? 12 : 14,
                       fontFamily: 'Poppins, sans-serif',
                       cursor: submitting ? 'not-allowed' : 'pointer',
                       opacity: submitting ? 0.6 : 1,
+                      whiteSpace: 'nowrap',
+                      flexShrink: 0,
                       transition: 'all 0.15s',
                     }}
                   >
-                    I don't know
+                    {isCompactNav ? 'Unsure' : "I don't know"}
                   </button>
                 </div>
               )}
@@ -258,7 +279,7 @@ export default function HowPage() {
                 onMouseEnter={() => answers[questionIdx].trim() && !submitting && setHoveredNav('next')}
                 onMouseLeave={() => setHoveredNav(null)}
                 style={{
-                  padding: '10px 22px',
+                  padding: isCompactNav ? '9px 12px' : '10px 22px',
                   borderRadius: 10,
                   border: 'none',
                   background: answers[questionIdx].trim() && !submitting
@@ -266,11 +287,13 @@ export default function HowPage() {
                     : isDark ? 'rgba(255,255,255,0.08)' : '#e0e0e0',
                   color: answers[questionIdx].trim() && !submitting ? '#1a1a1a' : subText,
                   fontWeight: 700,
-                  fontSize: 14,
+                  fontSize: isCompactNav ? 12 : 14,
                   fontFamily: 'Poppins, sans-serif',
                   cursor: answers[questionIdx].trim() && !submitting ? 'pointer' : 'not-allowed',
                   transform: answers[questionIdx].trim() && !submitting && hoveredNav === 'next' ? 'translateY(-1px)' : 'none',
                   boxShadow: answers[questionIdx].trim() && !submitting && hoveredNav === 'next' ? '0 4px 12px rgba(0,0,0,0.12)' : 'none',
+                  whiteSpace: 'nowrap',
+                  flexShrink: 0,
                   transition: 'all 0.15s',
                 }}
               >

--- a/frontend/src/pages/user/WhyPage.jsx
+++ b/frontend/src/pages/user/WhyPage.jsx
@@ -8,6 +8,14 @@ import { useTheme } from '../../context/ThemeContext'
 // Step 0 = stance, steps 1–5 = follow-up questions
 const TOTAL_QUESTION_STEPS = 5
 
+const WHY_QUESTIONS = [
+  'Why does this issue matter to you?',
+  'What is driving that feeling?',
+  'Why do you think that happens?',
+  'Why does that specific root cause concern you the most?',
+  'Ultimately, what is the core belief or value behind your thoughts?',
+]
+
 const STANCE_OPTIONS = [
   { key: 'agree',    base: '#ccf6e2', hover: '#b5ead7', selected: '#7fd3b5', label: 'Agree' },
   { key: 'disagree', base: '#ffd6d6', hover: '#ffc2c2', selected: '#ff8787', label: 'Disagree' },
@@ -33,6 +41,7 @@ export default function WhyPage() {
   const [answers, setAnswers] = useState(Array(TOTAL_QUESTION_STEPS).fill(''))
   const [submitting, setSubmitting] = useState(false)
   const [hoveredNav, setHoveredNav] = useState(null)
+  const [isCompactNav, setIsCompactNav] = useState(false)
 
   const inputRef = useRef(null)
   const topRef   = useRef(null)
@@ -47,6 +56,16 @@ export default function WhyPage() {
     if (currentStep > 0) inputRef.current?.focus()
     topRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }, [currentStep])
+
+  useEffect(() => {
+    const updateNavLayout = () => {
+      setIsCompactNav(window.innerWidth < 420)
+    }
+
+    updateNavLayout()
+    window.addEventListener('resize', updateNavLayout)
+    return () => window.removeEventListener('resize', updateNavLayout)
+  }, [])
 
   const submitWhy = async () => {
     if (submitting) return
@@ -274,9 +293,7 @@ export default function WhyPage() {
 
               {/* Question label */}
               <p style={{ fontWeight: 600, fontSize: 20, color: textColor, marginBottom: 60 }}>
-                {currentStep === 1
-                  ? 'Why does this issue matter to you?'
-                  : 'Why does that matter to you?'}
+                {WHY_QUESTIONS[questionIdx]}
               </p>
 
               {/* Info hint */}
@@ -336,7 +353,7 @@ export default function WhyPage() {
               />
 
               {/* Navigation row */}
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginTop: 14, gap: 10, flexWrap: 'wrap' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginTop: 14, gap: 10, flexWrap: 'nowrap' }}>
 
                 {/* Back */}
                 <button
@@ -344,15 +361,17 @@ export default function WhyPage() {
                   onMouseEnter={() => setHoveredNav('back')}
                   onMouseLeave={() => setHoveredNav(null)}
                   style={{
-                    padding: '10px 18px',
+                    padding: isCompactNav ? '9px 12px' : '10px 18px',
                     borderRadius: 10,
                     border: `1px solid ${isDark ? 'rgba(255,255,255,0.12)' : '#ddd'}`,
                     background: hoveredNav === 'back' ? (isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.04)') : 'transparent',
                     color: textColor,
                     fontWeight: 600,
-                    fontSize: 14,
+                    fontSize: isCompactNav ? 13 : 14,
                     fontFamily: 'Poppins, sans-serif',
                     cursor: 'pointer',
+                    whiteSpace: 'nowrap',
+                    flexShrink: 0,
                     transition: 'all 0.15s',
                   }}
                 >
@@ -360,10 +379,10 @@ export default function WhyPage() {
                 </button>
 
                 {/* Right side: I don't know + Next/Finish */}
-                <div style={{ display: 'flex', gap: 8, alignItems: 'flex-end', flexWrap: 'wrap' }}>
+                <div style={{ display: 'flex', gap: isCompactNav ? 6 : 8, alignItems: 'flex-end', flexWrap: 'nowrap', justifyContent: 'flex-end', minWidth: 0, flex: 1 }}>
                   {currentStep >= 2 && (
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'flex-end' }}>
-                      <span style={{ fontSize: 11, color: subText, maxWidth: 150, textAlign: 'right', lineHeight: 1.4 }}>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'flex-end', minWidth: 0, flexShrink: 1 }}>
+                      <span style={{ display: isCompactNav ? 'none' : 'block', fontSize: 11, color: subText, maxWidth: 150, textAlign: 'right', lineHeight: 1.4 }}>
                         Unsure how to continue? This would end follow-ups.
                       </span>
                       <button
@@ -372,20 +391,22 @@ export default function WhyPage() {
                         onMouseEnter={() => !submitting && setHoveredNav('idontknow')}
                         onMouseLeave={() => setHoveredNav(null)}
                         style={{
-                          padding: '10px 18px',
+                          padding: isCompactNav ? '9px 12px' : '10px 18px',
                           borderRadius: 10,
                           border: `1px solid ${isDark ? 'rgba(255,255,255,0.18)' : '#bbb'}`,
                           background: hoveredNav === 'idontknow' ? (isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.05)') : 'transparent',
                           color: textColor,
                           fontWeight: 600,
-                          fontSize: 14,
+                          fontSize: isCompactNav ? 12 : 14,
                           fontFamily: 'Poppins, sans-serif',
                           cursor: submitting ? 'not-allowed' : 'pointer',
                           opacity: submitting ? 0.6 : 1,
+                          whiteSpace: 'nowrap',
+                          flexShrink: 0,
                           transition: 'all 0.15s',
                         }}
                       >
-                        I don't know
+                        {isCompactNav ? 'Unsure' : "I don't know"}
                       </button>
                     </div>
                   )}
@@ -396,7 +417,7 @@ export default function WhyPage() {
                     onMouseEnter={() => answers[questionIdx].trim() && !submitting && setHoveredNav('next')}
                     onMouseLeave={() => setHoveredNav(null)}
                     style={{
-                      padding: '10px 22px',
+                      padding: isCompactNav ? '9px 12px' : '10px 22px',
                       borderRadius: 10,
                       border: 'none',
                       background: answers[questionIdx].trim() && !submitting
@@ -404,11 +425,13 @@ export default function WhyPage() {
                         : isDark ? 'rgba(255,255,255,0.08)' : '#e0e0e0',
                       color: answers[questionIdx].trim() && !submitting ? '#1a1a1a' : subText,
                       fontWeight: 700,
-                      fontSize: 14,
+                      fontSize: isCompactNav ? 12 : 14,
                       fontFamily: 'Poppins, sans-serif',
                       cursor: answers[questionIdx].trim() && !submitting ? 'pointer' : 'not-allowed',
                       transform: answers[questionIdx].trim() && !submitting && hoveredNav === 'next' ? 'translateY(-1px)' : 'none',
                       boxShadow: answers[questionIdx].trim() && !submitting && hoveredNav === 'next' ? '0 4px 12px rgba(0,0,0,0.12)' : 'none',
+                      whiteSpace: 'nowrap',
+                      flexShrink: 0,
                       transition: 'all 0.15s',
                     }}
                   >


### PR DESCRIPTION
### Description

This PR introduces dynamic contextual prompts for the 5-Whys and 5-Hows ladders, resolving a key user feedback issue regarding potential confusion (perceived system glitches) for neurodivergent and general users during consecutive question flows. It also fixes responsive layout issues on mobile devices.

### Checklist

Please verify that the following have been completed before requesting review:
- [x] The code builds successfully.
- [x] All new and existing tests pass locally.
- [x] UI changes are demonstrated with screenshots below.

### Screenshots (if applicable)

<img width="1265" height="1027" alt="image" src="https://github.com/user-attachments/assets/15b699bc-e4c9-460c-a643-4eecae334911" />
<img width="1219" height="957" alt="image" src="https://github.com/user-attachments/assets/1628e614-6463-4126-8066-60dc1ad6d312" />
<img width="1260" height="978" alt="image" src="https://github.com/user-attachments/assets/619a3ba6-aa0a-41b3-9613-66d699584a8f" />
<img width="1270" height="946" alt="image" src="https://github.com/user-attachments/assets/a5d38fd5-831e-44f6-a873-409468285cf7" />

<img width="1317" height="841" alt="image" src="https://github.com/user-attachments/assets/18c341b9-d59b-421b-9f5a-1ffaa29c54a1" />
<img width="1272" height="910" alt="image" src="https://github.com/user-attachments/assets/cde62f76-c4f6-4cd2-8110-04f26c19c301" />
<img width="1284" height="890" alt="image" src="https://github.com/user-attachments/assets/a64cb433-4c27-4478-9bf0-e62591460801" />
<img width="1289" height="838" alt="image" src="https://github.com/user-attachments/assets/70fb01d5-8df8-43a7-acc1-7ba2bf760c94" />
<img width="1277" height="974" alt="image" src="https://github.com/user-attachments/assets/eb1d1cd6-9cad-4e9b-9862-4dac629b2d69" />


### Related Issues / References

Closes #292
* Implemented UX feedback loop regarding the Why/How ladder clarity for neurodivergent users.

### Reviewer Notes

* **Focus Areas:** Please review the responsiveness of the text input container and progressive headers on smaller mobile screen breakpoints.
* **Verification Needed:** Please help check if the email link can send properly within this context/environment or not.